### PR TITLE
Updated fetch information to use a newer stable SDL version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ if(SDL_VENDORED)
 	FetchContent_Declare(
 		SDL3
 		GIT_REPOSITORY https://github.com/libsdl-org/SDL
-		GIT_TAG preview-3.1.6
+		GIT_TAG release-3.2.24
 	)
 	FetchContent_MakeAvailable(SDL3)
 else()

--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ Despite the code overall being MPL, keep in mind shader code is non-commercial, 
 
 Texture is from https://opengameart.org/content/wall-grass-rock-stone-wood-and-dirt-480 by West
 
-It uses SDL 3.1.6 currently, fetched directly from Github by the CMake script.
+It uses SDL 3.2.24 currently, fetched directly from Github by the CMake script.


### PR DESCRIPTION
SDL 3.2.24 release instead of 3.1.6 preview.